### PR TITLE
README: improve formatting of important files

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,19 +105,17 @@ There's so much to be done any help is appreciated, at the moment I have a bruta
 
 **Getting around the code**
 
-```sh
-/WebKit/ This is a modified version of Apple's official repo.
-/WebKit/Source/WebCore This is where 90% of the work is done.
-/WebKit/Source/WebCore/bindings/scripts This is an important folder where WebKit autogenerates bindings
-/WebKit/Source/WTF/ is a cross-platform library for common tasks such as HashMaps, etc.
-/WebKit/Source/WTF/PlatformJS.h these are C++ pre-process settings for PLATFORM(JS)
-/WebKit/Source/WebCore/Configurations/ these are important compile-time configurations for WebCore
+* `/WebKit/` This is a modified version of Apple's official repo.
+* `/WebKit/Source/WebCore` This is where 90% of the work is done.
+* `/WebKit/Source/WebCore/bindings/scripts` This is an important folder where WebKit autogenerates bindings
+* `/WebKit/Source/WTF/` is a cross-platform library for common tasks such as HashMaps, etc.
+* `/WebKit/Source/WTF/PlatformJS.h` these are C++ pre-process settings for PLATFORM(JS)
+* `/WebKit/Source/WebCore/Configurations/` these are important compile-time configurations for WebCore
 
-/WebKitJS/ When compiled the output of WebKit is placed in WebKitJS/webkit.js
-/WebKitJS/tools/ Any helpful tools i've come across (only one for now...)
-/WebKitJS/tools/cppfilter.js  This demangles C++ symbols contained in emscripten.js
-/WebKitJS/tools/EmscriptenXcode.plugin This is a Xcode plugin, and a temporary hack for using emscripten
-```
+* `/WebKitJS/` When compiled the output of WebKit is placed in WebKitJS/webkit.js
+* `/WebKitJS/tools/` Any helpful tools i've come across (only one for now...)
+* `/WebKitJS/tools/cppfilter.js`  This demangles C++ symbols contained in emscripten.js
+* `/WebKitJS/tools/EmscriptenXcode.plugin` This is a Xcode plugin, and a temporary hack for using emscripten
 
 **It's important to know**
 


### PR DESCRIPTION
Previously, this entire block was in a script block.  This looked shitty:

![image](https://f.cloud.github.com/assets/23369/1935682/b8c2c7ca-7efc-11e3-9e0b-e0382cdd4bcd.png)

Now it's an unordered list (since it's an unordered list), and only the filenames are monospaced.  This sets them apart from the text describing them, making everything easier to read:

![image](https://f.cloud.github.com/assets/23369/1935686/c6fb71de-7efc-11e3-8e4b-95a2604b706f.png)
